### PR TITLE
Postrel/v0.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,11 +97,8 @@ jobs:
     needs: [build_diskim, build_appimage]
     runs-on: ubuntu-latest
     steps:
-      - name: Get current date
-        id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
       - name: "Get artifacts"
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: Move and rename appimage
         run: mv */*.AppImage arbor-gui.AppImage
       - name: Move and rename dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,12 +103,21 @@ jobs:
         run: mv */*.AppImage arbor-gui.AppImage
       - name: Move and rename dmg
         run: mv */*.dmg arbor-gui.dmg
+      - name: "Clone w/ submodules"
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: "recursive"
+          path: gui
+      - name: Make tarball
+        run: |
+          arbor/scripts/create_tarball $GITHUB_WORKSPACE/gui ${{ github.event.release.tag_name }} arbor-gui-${{ github.event.release.tag_name }}-full.tar.gz
       - name: "Make Release"
         uses: ncipollo/release-action@v1
         with:
           omitBody: true
           draft: true
           prerelease: false
-          artifacts: '*.dmg,*.AppImage'
+          artifacts: '*.dmg,*.AppImage,*.tar.gz'
           token: ${{ secrets.GITHUB_TOKEN }}
           

--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,15 @@
+@software{thorsten_hater_2022_7415130,
+  author       = {Thorsten Hater and
+                  Brent Huisman and
+                  Robin De Schepper and
+                  Nora Abi Akar and
+                  Benjamin Cumming and
+                  Sebastian Schmitt},
+  title        = {Arbor GUI v0.8},
+  month        = dec,
+  year         = 2022,
+  publisher    = {Zenodo},
+  version      = {v0.8},
+  doi          = {10.5281/zenodo.7415130},
+  url          = {https://doi.org/10.5281/zenodo.7415130}
+} 

--- a/README.md
+++ b/README.md
@@ -206,3 +206,7 @@ Test and example datasets include:
 -   A morphology model `dend-C060114A2_axon-C060114A5.asc` copyright of
     the BBP, licensed under the [CC BY-NC-SA 4.0
     license](https://creativecommons.org/licenses/by-nc-sa/4.0/).
+
+### Citing Arbor GUI
+
+The Arbor GUI entry on Zenodo can be cited, see [CITATION.bib](CITATION.bib).

--- a/scripts/create_tarball
+++ b/scripts/create_tarball
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# creates a tar ball of Arbor for e.g. releases
+#
+# checks out repo at a specific branch/commit/tag
+# strips version control,
+# but leaves (empty) .git directories of submodules (CMake checks for it)
+
+set -Eeuo pipefail
+
+if [[ "$#" -ne 3 ]]; then
+    echo "usage: create_tarball.sh path_to_repo branch/commit/tag path_to_output_tarball"
+	exit 1
+fi
+
+trap cleanup SIGINT SIGTERM ERR EXIT
+
+cleanup() {
+  trap - SIGINT SIGTERM ERR EXIT
+  rm -rf "$TMP_DIR"
+}
+
+TMP_DIR=$(mktemp -d)
+
+REPO=$1
+CHECKOUT=$2
+OUT_TARBALL=$3
+
+if [[ ! "$TMP_DIR" || ! -d "$TMP_DIR" ]]; then
+  echo "Could not create temporary directory"
+  exit 1
+fi
+
+REPO_NAME=arbor
+
+cd "$TMP_DIR"
+git clone "$REPO" $REPO_NAME
+cd "$REPO_NAME"
+git checkout "$CHECKOUT"
+git submodule init
+git submodule update
+
+# remove main .git
+rm -vrf .git
+
+# wipe .git submodule files
+find -type f -name .git | xargs truncate -s 0
+
+# create tar ball
+cd ..
+tar vcfz "$OUT_TARBALL" $REPO_NAME


### PR DESCRIPTION
- Remove (soon to be) deprecated stuff in CI
- Have a script to generate tarballs including git submodules (copied from Arbor) and auto-add them to the draft release that is created whenever a tag is push
  - After this PR is merged, I'll test this by pushing a `-rc` tag.
- Have CITATION.bib which mentions our brand new Zenodo entry!