### PR TITLE
Update Arbor to v0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ Next, follow the platform specific instructions.
     ``` bash
     sudo apt update
     sudo apt install build-essential libssl-dev \ 
-                     libxml2-dev libxrandr-dev libxinerama-dev \
+                     libxrandr-dev libxinerama-dev \
                      libxcursor-dev libxi-dev libglu1-mesa-dev \
-                     freeglut3-dev mesa-common-dev gcc-10 g++-10
+                     freeglut3-dev mesa-common-dev
     ```
     If your cmake version is less than 3.18, you will need to update it
     as well

--- a/src/gui_state.cpp
+++ b/src/gui_state.cpp
@@ -1080,33 +1080,33 @@ void gui_state::deserialize(const std::filesystem::path& fn) {
       return id;
     }
 
-    void operator()(const arb::init_membrane_potential& t) { state->parameter_defs[region].Vm = t.value; }
-    void operator()(const arb::axial_resistivity& t)       { state->parameter_defs[region].RL = t.value; }
-    void operator()(const arb::temperature_K& t)           { state->parameter_defs[region].TK = t.value; }
-    void operator()(const arb::membrane_capacitance& t)    { state->parameter_defs[region].Cm = t.value; }
+    void operator()(const arb::init_membrane_potential& t) { state->parameter_defs[region].Vm = t.value.get_scalar(); }
+    void operator()(const arb::axial_resistivity& t)       { state->parameter_defs[region].RL = t.value.get_scalar(); }
+    void operator()(const arb::temperature_K& t)           { state->parameter_defs[region].TK = t.value.get_scalar(); }
+    void operator()(const arb::membrane_capacitance& t)    { state->parameter_defs[region].Cm = t.value.get_scalar(); }
     void operator()(const arb::init_int_concentration& t) {
       auto ion = std::find_if(state->ions.begin(), state->ions.end(),
                               [&](const auto& id) { return state->ion_defs[id].name == t.ion; });
       if (ion == state->ions.end()) log_error("Unknown ion");
-      state->ion_par_defs[{region, *ion}].Xi = t.value;
+      state->ion_par_defs[{region, *ion}].Xi = t.value.get_scalar();
     }
     void operator()(const arb::init_ext_concentration& t) {
       auto ion = std::find_if(state->ions.begin(), state->ions.end(),
                               [&](const auto& id) { return state->ion_defs[id].name == t.ion; });
       if (ion == state->ions.end()) log_error("Unknown ion");
-      state->ion_par_defs[{region, *ion}].Xo = t.value;
+      state->ion_par_defs[{region, *ion}].Xo = t.value.get_scalar();
     }
     void operator()(const arb::init_reversal_potential& t) {
       auto ion = std::find_if(state->ions.begin(), state->ions.end(),
                               [&](const auto& id) { return state->ion_defs[id].name == t.ion; });
       if (ion == state->ions.end()) log_error("Unknown ion");
-      state->ion_par_defs[{region, *ion}].Er = t.value;
+      state->ion_par_defs[{region, *ion}].Er = t.value.get_scalar();
     }
     void operator()(const arb::ion_diffusivity& t) {
       auto ion = std::find_if(state->ions.begin(), state->ions.end(),
                               [&](const auto& id) { return state->ion_defs[id].name == t.ion; });
       if (ion == state->ions.end()) log_error("Unknown ion");
-      state->ion_par_defs[{region, *ion}].D = t.value;
+      state->ion_par_defs[{region, *ion}].D = t.value.get_scalar();
     }
     void operator()(const arb::scaled_mechanism<arb::density>& s) {
       auto id = make_density(s.t_mech);
@@ -1479,8 +1479,7 @@ void gui_state::run_simulation() {
                       t.values.push_back(*value);
                     }
                     sim.traces[t.id] = t;                    
-                  },
-                 arb::sampling_policy::exact);
+                  });
   try {
     sm.run(sim.until, sim.dt);
   } catch (...) {


### PR DESCRIPTION
Problems:

```
FAILED: CMakeFiles/arbor-gui.dir/src/gui_state.cpp.o 
/usr/bin/c++ -DARBORGUI_RESOURCES_BASE=\"/usr/local/share/arbor-gui\" -DFMT_HEADER_ONLY -DGLBINDING_STATIC_DEFINE -DSYSTEM_LINUX -I/home/user/groot/julich/code/arbor-gui/src -I/home/user/build/gui -I/home/user/groot/julich/code/arbor-gui/3rd-party/arbor/arbor/include -I/home/user/build/gui/3rd-party/arbor/arbor/include -I/home/user/groot/julich/code/arbor-gui/3rd-party/arbor/arborio/include -I/home/user/build/gui/3rd-party/arbor/arborio/include -I/home/user/groot/julich/code/arbor-gui/3rd-party/arbor/ext/json/include -I/home/user/groot/julich/code/arbor-gui/3rd-party/glbinding/source/glbinding/include -I/home/user/build/gui/3rd-party/glbinding/source/glbinding/include -I/home/user/groot/julich/code/arbor-gui/3rd-party/glfw/include -isystem /home/user/groot/julich/code/arbor-gui/3rd-party/fmt/include -isystem /home/user/groot/julich/code/arbor-gui/3rd-party/icons -isystem /home/user/groot/julich/code/arbor-gui/3rd-party/spdlog/include -isystem /home/user/groot/julich/code/arbor-gui/3rd-party/json/include -isystem /home/user/groot/julich/code/arbor-gui/3rd-party/imgui -isystem /home/user/groot/julich/code/arbor-gui/3rd-party/implot -isystem /home/user/groot/julich/code/arbor-gui/3rd-party/ImGuizmo -isystem /home/user/groot/julich/code/arbor-gui/3rd-party/glm -isystem /home/user/groot/julich/code/arbor-gui/3rd-party/stb -isystem /home/user/groot/julich/code/arbor-gui/3rd-party/imgui/backends -O3 -DNDEBUG -std=gnu++20 -MD -MT CMakeFiles/arbor-gui.dir/src/gui_state.cpp.o -MF CMakeFiles/arbor-gui.dir/src/gui_state.cpp.o.d -o CMakeFiles/arbor-gui.dir/src/gui_state.cpp.o -c /home/user/groot/julich/code/arbor-gui/src/gui_state.cpp
In file included from /usr/include/c++/12/bits/char_traits.h:42,
                 from /usr/include/c++/12/string:40,
                 from /home/user/groot/julich/code/arbor-gui/src/gui_state.hpp:3,
                 from /home/user/groot/julich/code/arbor-gui/src/gui_state.cpp:1:
/usr/include/c++/12/type_traits: In substitution of ‘template<class _Fn, class ... _Args> using invoke_result_t = typename std::invoke_result::type [with _Fn = gui_state::deserialize(const std::filesystem::__cxx11::path&)::rg_visitor; _Args = {const arb::voltage_process&}]’:
/usr/include/c++/12/variant:1102:14:   required from ‘constexpr bool std::__detail::__variant::__check_visitor_results(std::index_sequence<_Idx ...>) [with _Visitor = gui_state::deserialize(const std::filesystem::__cxx11::path&)::rg_visitor; _Variant = const std::variant<arb::init_membrane_potential, arb::axial_resistivity, arb::temperature_K, arb::membrane_capacitance, arb::ion_diffusivity, arb::init_int_concentration, arb::init_ext_concentration, arb::init_reversal_potential, arb::density, arb::voltage_process, arb::scaled_mechanism<arb::density> >&; long unsigned int ..._Idxs = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}; std::index_sequence<_Idx ...> = std::integer_sequence<long unsigned int, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10>]’
/usr/include/c++/12/variant:1836:44:   required from ‘constexpr std::__detail::__variant::__visit_result_t<_Visitor, _Variants ...> std::visit(_Visitor&&, _Variants&& ...) [with _Visitor = gui_state::deserialize(const std::filesystem::__cxx11::path&)::rg_visitor; _Variants = {const variant<arb::init_membrane_potential, arb::axial_resistivity, arb::temperature_K, arb::membrane_capacitance, arb::ion_diffusivity, arb::init_int_concentration, arb::init_ext_concentration, arb::init_reversal_potential, arb::density, arb::voltage_process, arb::scaled_mechanism<arb::density> >&}; __detail::__variant::__visit_result_t<_Visitor, _Variants ...> = void]’
/home/user/groot/julich/code/arbor-gui/src/gui_state.cpp:1172:62:   required from here
/usr/include/c++/12/type_traits:3034:11: error: no type named ‘type’ in ‘struct std::invoke_result<gui_state::deserialize(const std::filesystem::__cxx11::path&)::rg_visitor, const arb::voltage_process&>’
 3034 |     using invoke_result_t = typename invoke_result<_Fn, _Args...>::type;
      |           ^~~~~~~~~~~~~~~
In file included from /home/user/groot/julich/code/arbor-gui/3rd-party/arbor/arbor/include/arbor/cable_cell.hpp:7,
                 from /home/user/groot/julich/code/arbor-gui/src/gui_state.hpp:8:
/usr/include/c++/12/variant: In instantiation of ‘constexpr std::__detail::__variant::__visit_result_t<_Visitor, _Variants ...> std::visit(_Visitor&&, _Variants&& ...) [with _Visitor = gui_state::deserialize(const std::filesystem::__cxx11::path&)::rg_visitor; _Variants = {const variant<arb::init_membrane_potential, arb::axial_resistivity, arb::temperature_K, arb::membrane_capacitance, arb::ion_diffusivity, arb::init_int_concentration, arb::init_ext_concentration, arb::init_reversal_potential, arb::density, arb::voltage_process, arb::scaled_mechanism<arb::density> >&}; __detail::__variant::__visit_result_t<_Visitor, _Variants ...> = void]’:
/home/user/groot/julich/code/arbor-gui/src/gui_state.cpp:1172:62:   required from here
/usr/include/c++/12/variant:1836:44:   in ‘constexpr’ expansion of ‘std::__detail::__variant::__check_visitor_results<gui_state::deserialize(const std::filesystem::__cxx11::path&)::rg_visitor, const std::variant<arb::init_membrane_potential, arb::axial_resistivity, arb::temperature_K, arb::membrane_capacitance, arb::ion_diffusivity, arb::init_int_concentration, arb::init_ext_concentration, arb::init_reversal_potential, arb::density, arb::voltage_process, arb::scaled_mechanism<arb::density> >&, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10>((std::make_index_sequence<11>(), std::make_index_sequence<11>()))’
/usr/include/c++/12/variant:1835:26: error: ‘constexpr’ call flows off the end of the function
 1835 |           constexpr bool __visit_rettypes_match = __detail::__variant::
      |                          ^~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/12/variant:1840:29: error: non-constant condition for static assertion
 1840 |               static_assert(__visit_rettypes_match,
      |                             ^~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/12/variant: In instantiation of ‘static constexpr decltype(auto) std::__detail::__variant::__gen_vtable_impl<std::__detail::__variant::_Multi_array<_Result_type (*)(_Visitor, _Variants ...)>, std::integer_sequence<long unsigned int, __indices ...> >::__visit_invoke(_Visitor&&, _Variants ...) [with _Result_type = std::__detail::__variant::__deduce_visit_result<void>; _Visitor = gui_state::deserialize(const std::filesystem::__cxx11::path&)::rg_visitor&&; _Variants = {const std::variant<arb::init_membrane_potential, arb::axial_resistivity, arb::temperature_K, arb::membrane_capacitance, arb::ion_diffusivity, arb::init_int_concentration, arb::init_ext_concentration, arb::init_reversal_potential, arb::density, arb::voltage_process, arb::scaled_mechanism<arb::density> >&}; long unsigned int ...__indices = {9}]’:
/usr/include/c++/12/variant:1792:5:   required from ‘constexpr decltype(auto) std::__do_visit(_Visitor&&, _Variants&& ...) [with _Result_type = __detail::__variant::__deduce_visit_result<void>; _Visitor = gui_state::deserialize(const std::filesystem::__cxx11::path&)::rg_visitor; _Variants = {const variant<arb::init_membrane_potential, arb::axial_resistivity, arb::temperature_K, arb::membrane_capacitance, arb::ion_diffusivity, arb::init_int_concentration, arb::init_ext_concentration, arb::init_reversal_potential, arb::density, arb::voltage_process, arb::scaled_mechanism<arb::density> >&}]’
/usr/include/c++/12/variant:1846:34:   required from ‘constexpr std::__detail::__variant::__visit_result_t<_Visitor, _Variants ...> std::visit(_Visitor&&, _Variants&& ...) [with _Visitor = gui_state::deserialize(const std::filesystem::__cxx11::path&)::rg_visitor; _Variants = {const variant<arb::init_membrane_potential, arb::axial_resistivity, arb::temperature_K, arb::membrane_capacitance, arb::ion_diffusivity, arb::init_int_concentration, arb::init_ext_concentration, arb::init_reversal_potential, arb::density, arb::voltage_process, arb::scaled_mechanism<arb::density> >&}; __detail::__variant::__visit_result_t<_Visitor, _Variants ...> = void]’
/home/user/groot/julich/code/arbor-gui/src/gui_state.cpp:1172:62:   required from here
/usr/include/c++/12/variant:1031:31: error: no matching function for call to ‘__invoke(gui_state::deserialize(const std::filesystem::__cxx11::path&)::rg_visitor, const arb::voltage_process&)’
 1031 |           return std::__invoke(std::forward<_Visitor>(__visitor),
      |                  ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1032 |               __element_by_index_or_cookie<__indices>(
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1033 |                 std::forward<_Variants>(__vars))...);
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/12/bits/refwrap.h:38,
                 from /usr/include/c++/12/string:51:
/usr/include/c++/12/bits/invoke.h:90:5: note: candidate: ‘template<class _Callable, class ... _Args> constexpr typename std::__invoke_result<_Functor, _ArgTypes>::type std::__invoke(_Callable&&, _Args&& ...)’
   90 |     __invoke(_Callable&& __fn, _Args&&... __args)
      |     ^~~~~~~~
/usr/include/c++/12/bits/invoke.h:90:5: note:   template argument deduction/substitution failed:
/usr/include/c++/12/bits/invoke.h: In substitution of ‘template<class _Callable, class ... _Args> constexpr typename std::__invoke_result<_Functor, _ArgTypes>::type std::__invoke(_Callable&&, _Args&& ...) [with _Callable = gui_state::deserialize(const std::filesystem::__cxx11::path&)::rg_visitor; _Args = {const arb::voltage_process&}]’:
/usr/include/c++/12/variant:1031:24:   required from ‘static constexpr decltype(auto) std::__detail::__variant::__gen_vtable_impl<std::__detail::__variant::_Multi_array<_Result_type (*)(_Visitor, _Variants ...)>, std::integer_sequence<long unsigned int, __indices ...> >::__visit_invoke(_Visitor&&, _Variants ...) [with _Result_type = std::__detail::__variant::__deduce_visit_result<void>; _Visitor = gui_state::deserialize(const std::filesystem::__cxx11::path&)::rg_visitor&&; _Variants = {const std::variant<arb::init_membrane_potential, arb::axial_resistivity, arb::temperature_K, arb::membrane_capacitance, arb::ion_diffusivity, arb::init_int_concentration, arb::init_ext_concentration, arb::init_reversal_potential, arb::density, arb::voltage_process, arb::scaled_mechanism<arb::density> >&}; long unsigned int ...__indices = {9}]’
/usr/include/c++/12/variant:1792:5:   required from ‘constexpr decltype(auto) std::__do_visit(_Visitor&&, _Variants&& ...) [with _Result_type = __detail::__variant::__deduce_visit_result<void>; _Visitor = gui_state::deserialize(const std::filesystem::__cxx11::path&)::rg_visitor; _Variants = {const variant<arb::init_membrane_potential, arb::axial_resistivity, arb::temperature_K, arb::membrane_capacitance, arb::ion_diffusivity, arb::init_int_concentration, arb::init_ext_concentration, arb::init_reversal_potential, arb::density, arb::voltage_process, arb::scaled_mechanism<arb::density> >&}]’
/usr/include/c++/12/variant:1846:34:   required from ‘constexpr std::__detail::__variant::__visit_result_t<_Visitor, _Variants ...> std::visit(_Visitor&&, _Variants&& ...) [with _Visitor = gui_state::deserialize(const std::filesystem::__cxx11::path&)::rg_visitor; _Variants = {const variant<arb::init_membrane_potential, arb::axial_resistivity, arb::temperature_K, arb::membrane_capacitance, arb::ion_diffusivity, arb::init_int_concentration, arb::init_ext_concentration, arb::init_reversal_potential, arb::density, arb::voltage_process, arb::scaled_mechanism<arb::density> >&}; __detail::__variant::__visit_result_t<_Visitor, _Variants ...> = void]’
/home/user/groot/julich/code/arbor-gui/src/gui_state.cpp:1172:62:   required from here
/usr/include/c++/12/bits/invoke.h:90:5: error: no type named ‘type’ in ‘struct std::__invoke_result<gui_state::deserialize(const std::filesystem::__cxx11::path&)::rg_visitor, const arb::voltage_process&>’
ninja: build stopped: subcommand failed.
```